### PR TITLE
Filter empty pmaps

### DIFF
--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -93,8 +93,10 @@ def irene(files_in, file_out, compression, event_range, print_mod, run_number,
 
     ### Define data filters
 
-    # Filter events with zero peaks
+    # Filter events without signal over threshold
     empty_indices   = fl.count_filter(check_nonempty_indices, args = ("s1_indices", "s2_indices"))
+    # Filter events with zero peaks
+    empty_pmaps     = fl.count_filter(check_empty_pmap      , args = "pmap")
 
     event_count_in  = fl.spy_count()
     event_count_out = fl.spy_count()
@@ -124,6 +126,7 @@ def irene(files_in, file_out, compression, event_range, print_mod, run_number,
                                 empty_indices.filter,
                                 sipm_rwf_to_cal,
                                 compute_pmap,
+                                empty_pmaps.filter,
                                 event_count_out.spy,
                                 fl.fork(write_pmap,
                                         write_mc,
@@ -131,7 +134,8 @@ def irene(files_in, file_out, compression, event_range, print_mod, run_number,
                                         write_trigger_info)),
                     result = dict(events_in  = event_count_in .future,
                                   events_out = event_count_out.future,
-                                  empty_pmap = empty_indices  .future))
+                                  over_thr   = empty_indices  .future,
+                                  full_pmap  = empty_pmaps    .future))
 
 
 
@@ -169,3 +173,7 @@ def get_number_of_active_pmts(run_number):
 
 def check_nonempty_indices(s1_indices, s2_indices):
     return s1_indices.size and s2_indices.size
+
+
+def check_empty_pmap(pmap):
+    return pmap.s1s + pmap.s2s

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -201,7 +201,7 @@ def test_empty_events_issue_81(config_tmpdir, ICDATADIR, s12params):
 
     assert cnt.events_in           == 1
     assert cnt.events_out          == 0
-    assert cnt.empty_pmap.n_failed == 1
+    assert cnt.  over_thr.n_failed == 1
 
 
 @mark.skip
@@ -236,7 +236,7 @@ def test_irene_empty_pmap_output(ICDATADIR, output_tmpdir, s12params):
     cnt = irene(**conf)
 
     assert cnt.events_in           == 3
-    assert cnt.empty_pmap.n_failed == 0
+    assert cnt.  over_thr.n_failed == 0
 
     with tb.open_file(file_in) as fin:
         with tb.open_file(file_out) as fout:

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -151,8 +151,10 @@ def test_irene_runinfo_run_2983(config_tmpdir, ICDATADIR):
 
 
     with tb.open_file(PATH_IN, mode='r') as h5in:
-        evts_in = h5in.root.Run.events.cols.evt_number[:2]
-        ts_in   = h5in.root.Run.events.cols.timestamp [:2]
+        valid_events = (0,)
+
+        evts_in = h5in.root.Run.events.cols.evt_number[valid_events]
+        ts_in   = h5in.root.Run.events.cols.timestamp [valid_events]
 
         rundf, evtdf = read_run_and_event(PATH_OUT)
         evts_out     = evtdf.evt_number.values

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -405,8 +405,6 @@ def test_irene_exact_result(ICDATADIR, output_tmpdir):
               "Trigger/events" , "Trigger/trigger")
     with tb.open_file(true_output)  as true_output_file:
         with tb.open_file(file_out) as      output_file:
-            print(true_output_file)
-            print(     output_file)
             for table in tables:
                 got      = getattr(     output_file.root, table)
                 expected = getattr(true_output_file.root, table)

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -427,7 +427,9 @@ def test_irene_filters_empty_pmaps(ICDATADIR, output_tmpdir):
                      s2_tmin      = 0 * units.mus,
                      s2_tmax      = 1 * units.mus))
 
-    irene(**conf)
+    cnt = irene(**conf)
+
+    assert cnt.full_pmap.n_failed == 3
 
     tables = (     "MC/extents",      "MC/hits"   ,    "MC/particles", "MC/generators",
                 "PMAPS/S1"     ,   "PMAPS/S2"     , "PMAPS/S2Si"     ,


### PR DESCRIPTION
Add a filter for empty pmaps in `irene`. The lack of this filter creates a mismatch between the different tables in the file, producing output for mc tables or the event number table, but not for the pmaps table. This causes next stages of processing to fail.