### PR TITLE
Fix coverage version

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -103,6 +103,7 @@ dependencies:
 - flaky        = 3.4.0
 - hypothesis   = 3.68.0
 - pytest-xdist = 1.23.2
+- coverage     = 4.5.4
 - pip:
   - pytest-instafail==0.4.0
 EOF


### PR DESCRIPTION
Travis has started to fail in IC installations due to a newer version of the `coverage` package, which is not listed in our dependencies list but it is need by one of them.

You can see the failures here:

https://travis-ci.org/jmbenlloch/IC-1/jobs/565919414?utm_medium=notification&utm_source=github_status
https://travis-ci.org/nextic/ANTEA/jobs/637520045?utm_medium=notification&utm_source=github_status

This PR simply fixes the `coverage` version manually so new installations won't get the failing one.

I'm copying one sample error here so we can have it archived in case we needed it in the future:

```
    @given(random_length_float_arrays(mask = lambda x: ((x<-10) or

>                                                  (x>+10) )))

    def test_in_range_with_hole(data):

invisible_cities/core/core_functions_test.py:60: 

_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <hypothesis.core.StateForActualGivenExecution object at 0x7fe358f62910>

test_runner = <function default_new_style_executor at 0x7fe3811340e0>

search_strategy = tuples(just(()), fixed_dictionaries({'data': integers(min_value=0, max_value=100).flatmap(lambda n: float_arrays(n, **kwargs))}).map(lambda args: dict(args, **kwargs)))

test = <function test_in_range_with_hole at 0x7fe3596229e0>

settings = settings(buffer_size=8192, database=DirectoryBasedExampleDatabase('/home/travis/build/jmbenlloch/IC-1/.hypothesis/exam...INFER: 1>, stateful_step_count=50, suppress_health_check=(), timeout=60, use_coverage=True, verbosity=Verbosity.normal)

random = <random.Random object at 0x56103c016310>, had_seed = None

    def __init__(

        self, test_runner, search_strategy, test, settings, random, had_seed

    ):

        self.test_runner = test_runner

        self.search_strategy = search_strategy

        self.settings = settings

        self.last_exception = None

        self.falsifying_examples = ()

        self.__was_flaky = False

        self.random = random

        self.__warned_deadline = False

        self.__existing_collector = None

        self.__test_runtime = None

        self.__had_seed = had_seed

    

        self.test = test

    

        self.coverage_data = CoverageData()

        self.files_to_propagate = set()

        self.failed_normally = False

    

        self.used_examples_from_database = False

    

        if settings.use_coverage and not IN_COVERAGE_TESTS:  # pragma: no cover

            if Collector._collectors:

                parent = Collector._collectors[-1]

    

                # We include any files the collector has already decided to

                # trace whether or not on re-investigation we still think it

                # wants to trace them. The reason for this is that in some

                # cases coverage gets the wrong answer when we run it

                # ourselves due to reasons that are our fault but are hard to

                # fix (we lie about where certain functions come from).

                # This causes us to not record the actual test bodies as

                # covered. But if we intended to trace test bodies then the

                # file must already have been traced when getting to this point

                # and so will already be in the collector's data. Hence we can

                # use that information to get the correct answer here.

                # See issue 997 for more context.

                self.files_to_propagate = set(parent.data)

                self.hijack_collector(parent)

    

            self.collector = Collector(

                branch=True,

                timid=FORCE_PURE_TRACER,

                should_trace=self.should_trace,

                check_include=hypothesis_check_include,

                concurrency='thread',

>               warn=escalate_warning,

            )

E           TypeError: __init__() missing 2 required positional arguments: 'should_start_context' and 'file_mapper'

../../../miniconda/envs/IC-3.7-2018-11-14/lib/python3.7/site-packages/hypothesis/core.py:522: TypeError
```