### PR TITLE
Github action to check database status after calibration updates

### DIFF
--- a/.github/workflows/check_db_calibration.yml
+++ b/.github/workflows/check_db_calibration.yml
@@ -1,0 +1,42 @@
+# This workflow will check the consistency between MySQL and SQLite databases
+
+name: Calibration check
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+        - '**.sqlite3'
+  pull_request:
+    branches: [ master ]
+    paths:
+        - '**.sqlite3'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - id: files
+      uses: jitterbit/get-changed-files@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Get LFS files
+      run: |
+        git lfs pull
+    - name: Install dependencies
+      run: |
+        pip install pymysql numpy
+    - name: Check database
+      run: |
+        python invisible_cities/database/check_gain_update.py ${{ steps.files.outputs.all }}
+      env:
+        PYTHONPATH: "."
+

--- a/invisible_cities/database/check_gain_update.py
+++ b/invisible_cities/database/check_gain_update.py
@@ -1,0 +1,54 @@
+import sys
+import sqlite3
+import pymysql
+pymysql.install_as_MySQLdb()
+import numpy as np
+
+# Absolute imports to allow usage as standalone program:
+# python invisible_cities/database/check_gain_update.py
+from invisible_cities.database.db_connection import connect_sqlite
+from invisible_cities.database.db_connection import connect_mysql
+
+
+def check_minrun_maxrun(table, filters):
+    sql = f'select distinct(Minrun), maxrun from {table} where {filters} ORDER BY MinRun,MaxRun;'
+
+    cursor_sqlite.execute(sql)
+    cursor_mysql .execute(sql)
+
+    data_mysql  = cursor_mysql .fetchall()
+    data_sqlite = cursor_sqlite.fetchall()
+
+    # Convert to np float64 arrays to replace None's vy np.nan's
+    array_mysql  = np.array(data_mysql , dtype=np.float64)
+    array_sqlite = np.array(data_sqlite, dtype=np.float64)
+
+    np.testing.assert_allclose(array_mysql, array_sqlite)
+
+    try:
+        latest_run = data_sqlite[-1][0]
+    except IndexError:
+        latest_run = None
+
+    return latest_run
+
+
+# Get DB name from the list of updated files in the commit
+dbfile = next(filter(lambda f: f.endswith('sqlite3'), sys.argv))
+dbname = dbfile.split('.')[-2]
+
+# Connect to MySQL server and open SQLite copy
+_, cursor_sqlite = connect_sqlite(dbfile)
+_, cursor_mysql  = connect_mysql (dbname)
+
+# Check tables
+tables = ['ChannelGain', 'ChannelMask', 'SipmNoisePDF']
+pmts  = 'SensorID < 100'
+sipms = 'SensorID > 100'
+
+# Print latest run available in each case
+for table in tables:
+    latest_run_sipms = check_minrun_maxrun(table, sipms)
+    latest_run_pmts  = check_minrun_maxrun(table, pmts)
+    print(f'{table}: latest SiPM run {latest_run_sipms}')
+    print(f'{table}: latest PMT  run {latest_run_pmts}')

--- a/invisible_cities/database/db_connection.py
+++ b/invisible_cities/database/db_connection.py
@@ -1,0 +1,17 @@
+import sqlite3
+import pymysql
+pymysql.install_as_MySQLdb()
+
+
+def connect_sqlite(dbfile):
+    conn_sqlite   = sqlite3.connect(dbfile)
+    cursor_sqlite = conn_sqlite.cursor()
+    return conn_sqlite, cursor_sqlite
+
+
+def connect_mysql(dbname):
+    conn_mysql  = pymysql.connect(host="neutrinos1.ific.uv.es",
+                                  user='nextreader',passwd='readonly', db=dbname)
+    cursor_mysql  = conn_mysql .cursor()
+    return connect_mysql, cursor_mysql
+

--- a/invisible_cities/database/download.py
+++ b/invisible_cities/database/download.py
@@ -6,6 +6,11 @@ import os
 import re
 from os import path
 
+# Absolute imports to allow usage as standalone program:
+# python invisible_cities/database/download.py
+from invisible_cities.database.db_connection import connect_sqlite
+from invisible_cities.database.db_connection import connect_mysql
+
 
 tables = ['DetectorGeo','PmtBlr','ChannelGain','ChannelMapping','ChannelMask',
           'PmtNoiseRms','ChannelPosition','SipmBaseline', 'SipmNoisePDF',
@@ -58,21 +63,17 @@ def loadDB(dbname : str):
     except:
         pass
 
-    connSqlite = sqlite3.connect(dbfile)
-    connMySql  = pymysql.connect(host="neutrinos1.ific.uv.es",
-                                user='nextreader',passwd='readonly', db=dbname)
-
-    cursorMySql  = connMySql .cursor()
-    cursorSqlite = connSqlite.cursor()
+    conn_sqlite, cursor_sqlite = connect_sqlite(dbfile)
+    conn_mysql , cursor_mysql  = connect_mysql (dbname)
 
     for table in tables:
         print("Downloading table {}".format(table))
 
         # Create table
-        create_table_sqlite(cursorSqlite, cursorMySql, table)
+        create_table_sqlite(cursor_sqlite, cursor_mysql, table)
 
         # Copy data
-        copy_all_rows(connSqlite, cursorSqlite, cursorMySql, table)
+        copy_all_rows(conn_sqlite, cursor_sqlite, cursor_mysql, table)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Whenever a new calibration is done some tables are changed in our MySQL server, that are later reflected in the SQLite file uploaded to this repository (examples in #765, #759, #754, etc.). Usually I'm the one responsible of reviewing those PRs. Besides checking all tests passed in Travis there is an extra step to ensure everything is ok and there was no human error in the process of creating the `sqlite` copy. This PR shows a way to do it automatically.

The calibration in the database affects the tables `ChannelGain`, `ChannelMask` and `SipmNoisePDF`. All of them are indexed using a `MinRun` and a `MaxRun`, delimiting the range of runs to which those values are applicable. The set of (`MinRun`, `MaxRun`) for each of those tables must be the same in our MySQL server and in the `sqlite3` file included in the corresponding PR.

So far, I have been doing that step manually. This PR includes a Github action to do that check automatically. It will be triggered only for PR's modifying some `*.sqlite3` file. This is what it does:

- Detect which is the updated database by parsing the name of the updated file. So it is useful for NEW, DEMOPP, etc.
- Retrieve the (`MinRun`, `MaxRun`) set for the relevant tables and checks the SQLite file contains the same thing both for SiPMs and PMTs (separately).
- It does NOT check all the values (too much data), but only that there is consistency between the latest calibration run number in both databases.

As illustration I have already included the code in this PR into [my fork's master](https://github.com/jmbenlloch/IC-1) and created several PR's two show you how it works:

- [A PR updating DEMOPP database](https://github.com/jmbenlloch/IC-1/pull/3) without including the latest calibration in the MySQL server.
  - This PR passed all Travis tests but [did NOT passed the new test](https://github.com/jmbenlloch/IC-1/pull/3/checks?check_run_id=1696388822) done by the Github action included in this PR.
![image](https://user-images.githubusercontent.com/12936714/104498548-1ba69480-55dc-11eb-94f7-507c3e954596.png)

- [Another PR with the same idea for the NEW database](https://github.com/jmbenlloch/IC-1/pull/4).
  - The code autodetects the proper database to check and [shows the error](https://github.com/jmbenlloch/IC-1/pull/4/checks?check_run_id=1696737387).

- [One last PR modifying the DEMOPP sqlite](https://github.com/jmbenlloch/IC-1/pull/5) file but keeping the latest calibration in place.
  - [All tests passed](https://github.com/jmbenlloch/IC-1/pull/5/checks?check_run_id=1696446530) in this case.
![image](https://user-images.githubusercontent.com/12936714/104499146-ecdcee00-55dc-11eb-9f73-db054ff1b8fa.png)

I think this automation will simplify the reviewing of calibration PR's (which are common) and can also be useful as a proof of concept for tests/tasks that we want to run occasionally and do not fit well in the pytest scheme. This can be the first Github action included in IC, but there may be more in the future.

PS: In the sample images you can see a check called `Python package / build (3.7) (pull_request)`, I have updated that name to `Calibration check / build (3.7) (pull_request)`