### PR TITLE
Replace Travis with Github Actions

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -1,0 +1,36 @@
+# This workflow will install IC and run all the tests with pytest
+
+name: Test suite
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.7]
+        #platform: [ubuntu-18.04, macos-latest]
+        platform: [ubuntu-18.04]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get LFS files
+      run: git lfs pull
+    # - name: Fix Conda permissions on macOS
+    #   run: sudo chown -R $UID $CONDA
+    #   if: runner.os == 'macOS'
+    - name: Install IC
+      run: |
+        source $CONDA/etc/profile.d/conda.sh
+        source manage.sh work_in_python_version_no_tests ${{ matrix.python-version }}
+    - name: Run tests
+      run: |
+        source $CONDA/etc/profile.d/conda.sh
+        source manage.sh work_in_python_version_no_tests ${{ matrix.python-version }}
+        HYPOTHESIS_PROFILE=travis-ci bash manage.sh run_tests_par
+


### PR DESCRIPTION
Some of the latests PRs (#767, #761) are not running the tests in Travis. I have checked our travis account and it seems that there is a time limit for free accounts in travis-ci.com. Each free accounts gets 10000 "credits" but we have used all of them:

![image](https://user-images.githubusercontent.com/12936714/106152870-35201280-617e-11eb-9a6c-ece953def8b9.png)

An error message appears in our travis account: 

>Builds have been temporarily disabled for private and public repositories due to a negative credit balance. Please go to the Plan page to replenish your credit balance.

Since Github Actions does not impose any time limit for free accounts, I think we should move now to github and stop using Travis. This PR includes a first idea on how to implement our tests using a Github Action.

There are several issues:

- Tests are failing for different reasons: https://github.com/jmbenlloch/IC-1/actions/runs/517922412
  -  In linux, sometimes there is an [error in the database tests](https://github.com/jmbenlloch/IC-1/runs/1784584691?check_suite_focus=true). Ocasionally, there is a timeout error when connecting to our MySQL server at IFIC. I don't know the reason yet, especially because it is not deterministic. Here is a sample where it has run [successfully](https://github.com/jmbenlloch/IC-1/runs/1777615906?check_suite_focus=true). It might be related to the OS version used in the container that runs the jobs. Apparently `ubuntu-latest` is transitioning from 18.04 to 20.04. I'll try later to fix the version to 18.04 to check it.
  - In MacOS I have never seen a successful run. There are [some errors related to hypothesis](https://github.com/jmbenlloch/IC-1/runs/1784584730?check_suite_focus=true) and the timing of the tests. I do not know now how to address this problem.

DO NOT MERGE yet until we sort out the details. We need a reliable system to substitute Travis and for some reason we are not quite there yet. I think this is somehow urgent because, currently, we do not have any working CI system.