### PR TITLE
Fix database github action

### DIFF
--- a/.github/workflows/check_db_calibration.yml
+++ b/.github/workflows/check_db_calibration.yml
@@ -33,7 +33,7 @@ jobs:
         git lfs pull
     - name: Install dependencies
       run: |
-        pip install pymysql numpy
+        pip install pymysql numpy pytest
     - name: Check database
       run: |
         python invisible_cities/database/check_gain_update.py ${{ steps.files.outputs.all }}


### PR DESCRIPTION
For some reason the Github Action we use for calibration PRs is [not working anymore](https://github.com/next-exp/IC/pull/787/checks?check_run_id=2421133790). Apparently `pytest`was available by default before with the action `actions/setup-python@v2` but it is not anymore. This PR forces the installation of `pytest`.

I have already tested this change in my fork. I have included this commit in my fork's master and then submitted the same PR that is failing on IC (#787). In my fork, the [test passes without problem](https://github.com/jmbenlloch/IC-1/pull/7). 