### PR TITLE
Update database host

### DIFF
--- a/invisible_cities/database/db_connection.py
+++ b/invisible_cities/database/db_connection.py
@@ -13,7 +13,7 @@ def connect_sqlite(dbfile):
 
 @mark.skip(reason='server timeouts cause too many spurious test failures')
 def connect_mysql(dbname):
-    conn_mysql  = pymysql.connect(host="neutrinos1.ific.uv.es",
+    conn_mysql  = pymysql.connect(host="next.ific.uv.es",
                                   user='nextreader',passwd='readonly', db=dbname)
     cursor_mysql  = conn_mysql .cursor()
     return connect_mysql, cursor_mysql

--- a/invisible_cities/database/download_test.py
+++ b/invisible_cities/database/download_test.py
@@ -20,7 +20,7 @@ def test_create_table_sqlite(dbname, output_tmpdir):
     table = 'PmtBlr'
 
     connSqlite = sqlite3.connect(dbfile)
-    connMySql  = pymysql.connect(host="neutrinos1.ific.uv.es",
+    connMySql  = pymysql.connect(host="next.ific.uv.es",
                                  user='nextreader',passwd='readonly', db=dbname)
 
     cursorMySql  = connMySql .cursor()
@@ -41,7 +41,7 @@ def test_table_assignment(dbname):
 
 @mark.parametrize('dbname', db.dbnames)
 def test_tables_exist(dbname):
-    connMySql  = pymysql.connect(host="neutrinos1.ific.uv.es",
+    connMySql  = pymysql.connect(host="next.ific.uv.es",
                                  user='nextreader',passwd='readonly', db=dbname)
 
     cursor    = connMySql.cursor()


### PR DESCRIPTION
The MySQL database server we were using (neutrinos1) is too old and very difficult to update in that machine. I have migrated all the databases to a new server (next). This PR updates the hostname in the source code, so it can still download all the tables.

The phpmyadmin web interface is working with the new server already. In the future, new calibrations or any other changes must be performed either using phpmyadmin or connecting to the new server. The MySQL server at neutrinos1 will be stopped as soon as this PR is approved.