### PR TITLE
Update NEXT100 BLR coefficients

### DIFF
--- a/invisible_cities/database/localdb.NEXT100DB.sqlite3
+++ b/invisible_cities/database/localdb.NEXT100DB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:23a5c4d516ea55258a938b2caa554ae682c342ebe463bff103ad5e72c0716d65
-size 34779136
+oid sha256:f2b922be784b383f08c2862aaab9a2b921c529eae09c0599da6dd55d22dfec4f
+size 35291136


### PR DESCRIPTION
The BLR coefficients for channels 400, 401, 402 and 403 has been updated. The changes were reported by Raul in [CambiosRealizadosPMT26.pdf](https://github.com/user-attachments/files/17637140/CambiosRealizadosPMT26.pdf)

This PR includes the database with those changes implemented.