### PR TITLE
Bump miniconda version and use it in GHA

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -25,22 +25,23 @@ jobs:
     #   run: sudo chown -R $UID $CONDA
     #   if: runner.os == 'macOS'
 
+    - name: HACK! remove default conda
+      run: sudo unlink /usr/bin/conda
+
     - name: Install IC
       run: |
-        source $CONDA/etc/profile.d/conda.sh
         source manage.sh work_in_python_version_no_tests ${{ matrix.python-version }}
-
 
     - name: Run tests
       run: |
+        source scripts/setup_conda_gha.sh
         set -o pipefail # necessary for test failure to propagate to `tee`
-        source $CONDA/etc/profile.d/conda.sh
         source manage.sh work_in_python_version_no_tests ${{ matrix.python-version }}
         PYTEST_ADDOPTS=--color=yes HYPOTHESIS_PROFILE=travis-ci bash manage.sh run_tests_par | tee pytest_output
 
     - name: Test warning-catching script
       run: |
-        source $CONDA/etc/profile.d/conda.sh
+        source scripts/setup_conda_gha.sh
         source manage.sh work_in_python_version_no_tests ${{ matrix.python-version }}
 
         # write dummy tests

--- a/manage.sh
+++ b/manage.sh
@@ -60,7 +60,7 @@ function install_conda {
         echo Conda already installed. Skipping conda installation.
     else
         echo Installing conda for $CONDA_OS
-        CONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-py${PYTHON_VERSION//.}_4.9.2-${CONDA_OS}-x86_64.sh"
+        CONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-py${PYTHON_VERSION//.}_23.11.0-2-${CONDA_OS}-x86_64.sh"
         if which wget; then
             wget ${CONDA_URL} -O miniconda.sh
         else

--- a/scripts/setup_conda_gha.sh
+++ b/scripts/setup_conda_gha.sh
@@ -1,0 +1,3 @@
+export CONDA=$HOME/miniconda
+export PATH=$CONDA/bin:$PATH
+source $CONDA/etc/profile.d/conda.sh


### PR DESCRIPTION
Our repository comes with a setup script that provides the user with `miniconda` if they don't have one. The version of the `miniconda` package we download has been fixed for far too long. This PR bumps this version to the latest version that still supports python 3.8. This closes #931, but we will also need to update python to a newer version, which should como with an update to the `miniconda` installer as well.