### PR TITLE
Handle nested dictionaries in config parameter storage

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -211,10 +211,37 @@ def index_tables(file_out):
                 table.colinstances[colname].create_index()
 
 
+def dict_to_string(arg : dict,
+                   parent_key : str= ""):
+    '''
+    A function that recusively flattens nested dictionaries and converts the values to strings.
+
+    Each nested key is combined with its parent keys and associated with its respective value 
+    as a string.
+
+    Parameters
+    ----------
+    arg        : the dictionary to flatten which can contain nested dictionaries
+    parent_key : the string containing the prefix to use for keys in the flattened dictionary (default "").
+
+    Returns
+    -------
+    flat_dict : flattened dictionary containing no nested dictionaries and where all values are strings
+    '''
+    flat_dict = {}
+    for k, v in arg.items():
+        new_key = f"{parent_key}.{k}" if parent_key else k
+        if isinstance(v, dict):
+            flat_dict.update(dict_to_string(v, new_key))
+        else:
+            flat_dict[new_key] = str(v)
+    return flat_dict
+
+
 def write_city_configuration( filename : str
                             , city_name: str
                             , args     : dict):
-    args = {k: str(v) for k,v in args.items()}
+    args = dict_to_string(args)
 
     with tb.open_file(filename, "a") as file:
         df = (pd.Series(args)

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -575,15 +575,10 @@ def test_write_city_configuration(config_tmpdir):
         assert str(value) == df.value.loc[var]
 
     # considering just the nested dictionary
-    var, value = list(args.items())[-1]
-    for var1, value1 in value.items():
-        if not isinstance(value1, dict):
-            assert f"{var}.{var1}" in df.index        
-            assert  str(value1) == df.value.loc[f"{var}.{var1}"]
-        else:
-            for var2, value2 in value1.items():
-                assert f"{var}.{var1}.{var2}" in df.index        
-                assert  str(value2) == df.value.loc[f"{var}.{var1}.{var2}"]
+    assert 'g.a'        in df.index  and str(args['g']['a'])           == df.value.loc['g.a']
+    assert 'g.b'        in df.index  and str(args['g']['b'])           == df.value.loc['g.b']
+    assert 'g.c.alpha'  in df.index  and str(args['g']['c']['alpha'])  == df.value.loc['g.c.alpha']
+    assert 'g.c.beta'   in df.index  and str(args['g']['c']['beta'])   == df.value.loc['g.c.beta']
 
 
 def test_copy_cities_configuration(config_tmpdir):


### PR DESCRIPTION
This PR fixes #941 whereby some arguments in `write_city_configuration` were over the 300 character threshold. This issue occurred when passing dictionary arguments without unpacking them. This PR makes the `write_city_configuration` function sensitive to dictionary arguments and unpacks them, assigning sensible names. I have also added a case for this in the test function.