### PR TITLE
Alter list type to Tuples for sample_width and bin_size in Beersheba. 

### DIFF
--- a/invisible_cities/cities/beersheba.py
+++ b/invisible_cities/cities/beersheba.py
@@ -86,13 +86,12 @@ from .. types.symbols          import HitEnergy
 from .. types.symbols          import InterpolationMethod
 from .. types.symbols          import CutType
 from .. types.symbols          import DeconvolutionMode
-
+from .. types.ic_types         import Tuple2Dor3D
 
 from typing import Tuple
 from typing import List
 from typing import Optional
 from typing import Union
-
 
 def event_info_adder(timestamp : float, dst : pd.DataFrame):
     return dst.assign(time=timestamp/1e3, nsipm=0, Xrms=0, Yrms=0)
@@ -104,8 +103,8 @@ def deconvolve_signal(det_db           : pd.DataFrame,
                       e_cut            : float,
                       n_iterations     : int,
                       iteration_tol    : float,
-                      sample_width     : List[float],
-                      bin_size         : List[float],
+                      sample_width     : Tuple2Dor3D,
+                      bin_size         : Tuple2Dor3D,
                       satellite_params : Union[dict, NoneType],
                       diffusion        : Optional[Tuple[float, float, float]]=(1., 1., 0.3),
                       energy_type      : Optional[HitEnergy]=HitEnergy.Ec,

--- a/invisible_cities/config/beersheba.conf
+++ b/invisible_cities/config/beersheba.conf
@@ -16,13 +16,13 @@ same_peak = True
 
 deconv_params = dict(
   q_cut         = 10,
-  drop_dist     = [10., 10.],
+  drop_dist     = (10., 10.),
   psf_fname     = '$ICDIR/database/test_data/PSF_dst_sum_collapsed.h5',
   e_cut         = 1e-3,
   n_iterations  = 100,
   iteration_tol = 0.01,
-  sample_width  = [10., 10.],
-  bin_size      = [ 1.,  1.],
+  sample_width  = (10., 10.),
+  bin_size      = ( 1.,  1.),
   energy_type   = Ec,
   diffusion     = (1.0, 1.0),
   deconv_mode   = joint,

--- a/invisible_cities/reco/deconv_functions.py
+++ b/invisible_cities/reco/deconv_functions.py
@@ -25,7 +25,7 @@ from ..core .configure      import check_annotations
 from .. types.ic_types      import NoneType
 from .. types.symbols       import InterpolationMethod
 from .. types.symbols       import CutType
-
+from .. types.ic_types      import Tuple2Dor3D
 
 def collect_component_sizes(im_mask : np.ndarray) -> (np.ndarray, np.ndarray):
     '''
@@ -236,7 +236,7 @@ def drop_isolated_clusters(distance   :  List[float],
 
     return drop_event
 
-def deconvolution_input(sample_width : List[float     ],
+def deconvolution_input(sample_width : Tuple2Dor3D,
                         det_grid     : List[np.ndarray],
                         inter_method : InterpolationMethod = InterpolationMethod.cubic
                        ) -> Callable:
@@ -350,7 +350,7 @@ no_satellite_killer = dict(satellite_start_iter = None,
 @check_annotations
 def deconvolve(n_iterations         : int,
                iteration_tol        : float,
-               sample_width         : List[float],
+               sample_width         : Tuple2Dor3D,
                det_grid             : List[np.ndarray],
                satellite_start_iter : Union[int, NoneType],
                satellite_max_size   : int,

--- a/invisible_cities/types/ic_types.py
+++ b/invisible_cities/types/ic_types.py
@@ -1,11 +1,15 @@
 from enum        import Enum
 from collections import OrderedDict
+from typing  import Union
+from typing  import Tuple
 
 import numpy as np
 
 NN= -999999  # No Number, a trick to aovid nans in data structs
 
 NoneType = type(None)
+
+Tuple2Dor3D = Union[Tuple[float, float], Tuple[float, float, float]]
 
 class NNN:
 


### PR DESCRIPTION
This PR fixes #908 by changing the lists parameters in the config file of Beersheba to Tuples. At the same time it corrects functions which take this parameters by changing their expected input from lists to Tuples.