### PR TITLE
Resolve NameError when implementing satellite killer

### DIFF
--- a/invisible_cities/core/configure.py
+++ b/invisible_cities/core/configure.py
@@ -22,6 +22,7 @@ from . import system_of_units as     units
 from ..types.ic_types import NoneType
 from ..types.symbols  import ALL_SYMBOLS
 from ..types.symbols  import EventRange
+from ..types.symbols  import CutType
 
 from typing import get_origin
 from typing import get_args
@@ -103,7 +104,9 @@ def make_config_file_reader():
     builtins = __builtins__.copy()
     builtins.update(vars(units))
     builtins.update(ALL_SYMBOLS)
+    # include required 'builtins'
     builtins["np"] = np
+    builtins["CutType"] = CutType
 
     globals_ = {'__builtins__': builtins}
     config = Configuration()


### PR DESCRIPTION
A silly bug has slipped through the cracks!

When running satellite killer outwith Beersheba it behaves normally, but when trying to run it from the command line as `city Beersheba Beersheba_satkill.conf` you receive this error message:

```
Traceback (most recent call last):
  File "/home/e78368jw/Documents/NEXT_CODE/IC/bin/city", line 21, in <module>
    city_function(**configure(args))
  File "/home/e78368jw/Documents/NEXT_CODE/IC/invisible_cities/core/configure.py", line 78, in configure
    options = read_config_file(CLI.config_file)
  File "/home/e78368jw/Documents/NEXT_CODE/IC/invisible_cities/core/configure.py", line 89, in read_config_file
    whole_config               = read_top_level_config_file(full_file_name)
  File "/home/e78368jw/Documents/NEXT_CODE/IC/invisible_cities/core/configure.py", line 116, in read_included_file
    exec(config_file.read(), globals_, config)
  File "<string>", line 36, in <module>
NameError: name 'CutType' is not defined
```

Naively importing `CutType` does not resolve this issue. The problem appears to be due to the `globals_` used within [`exec()` ](https://github.com/next-exp/IC/blob/master/invisible_cities/core/configure.py#L114) not including CutType, but rather just the built-in imports (& numpy).

I believe the [Beersheba test](https://github.com/next-exp/IC/blob/master/invisible_cities/cities/beersheba_test.py#L115) doesn't capture this issue as it never uses `configure()` from `configure.py`, and as such never follows through the Traceback shown above.

This PR resolves this issue by including `CutType` into the dictionary of 'built-in' modules, but I believe this issue should be addressed more fully (perhaps an improvement in the output error of `read_included_file()` if the module isn't included in the `builtins`)