### PR TITLE
Avoid floating point comparison issues

### DIFF
--- a/invisible_cities/cities/beersheba.py
+++ b/invisible_cities/cities/beersheba.py
@@ -229,7 +229,10 @@ def deconvolve_signal(det_db           : pd.DataFrame,
             distribute_energy(deconvolved_hits, hits, energy_type)
             deco_dst.append(deconvolved_hits)
 
-        return pd.concat(deco_dst, ignore_index=True)
+        deco_dst   = pd.concat(deco_dst, ignore_index=True)
+        deco_dst.E = np.round(deco_dst.E, 6)
+
+        return deco_dst
 
     return apply_deconvolution
 

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -1490,6 +1490,7 @@ def track_blob_info_creator_extractor(vox_size         : Tuple[float, float, flo
         df = pd.DataFrame(columns=list(types_dict_tracks.keys()))
         if len(hitc.hits) > max_num_hits:
             return df, hitc, True
+        plf.round_hits_positions_in_place(hitc.hits)
         #track_hits is a new Hitcollection object that contains hits belonging to tracks, and hits that couldnt be corrected
         track_hitc = HitCollection(hitc.event, hitc.time)
         out_of_map = np.any(np.isnan([h.Ep for h in hitc.hits]))

--- a/invisible_cities/database/test_data/228Th_10evt_deco.h5
+++ b/invisible_cities/database/test_data/228Th_10evt_deco.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1567574839fd577d4166927fe2c58d0ce392c3dd30704ff842c7d9bf451f9179
-size 851835
+oid sha256:6dc45e3bd52cadaaf3a30cb984731bb5a8fd5034ebaeabd7f15b90692f9beef9
+size 835501

--- a/invisible_cities/database/test_data/228Th_10evt_deco_satellite.h5
+++ b/invisible_cities/database/test_data/228Th_10evt_deco_satellite.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b7576d91a7d5069117e6f85b4bae9ac68f6d25f9744c11b99623596856bcd2ca
-size 306487
+oid sha256:d215e7d7e20e226ae20c06f95e73fe6d167c4ff912297f0e6e8c1e5b449984ba
+size 303986

--- a/invisible_cities/database/test_data/228Th_10evt_deco_separate.h5
+++ b/invisible_cities/database/test_data/228Th_10evt_deco_separate.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8662b3b34f2e8d81dff2e48e406988276bd23b7eab3fde0e5b61590ca08deed4
-size 851846
+oid sha256:8eeaeba04ef24d1d4c30455c1b84c5fcd699438d69e5bbc9136c2eb6f4484ee3
+size 835533

--- a/invisible_cities/database/test_data/exact_Kr_deco_tracks_with_MC.h5
+++ b/invisible_cities/database/test_data/exact_Kr_deco_tracks_with_MC.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eb95e7bc313ec1882196a920c00349efaf4929b1e42503d3da508bdabc7cde96
-size 203628
+oid sha256:3b671cfec48800751bd265c4c7db4505311a55b9b7c6cb901d0ab2937f18330b
+size 210250

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -32,6 +32,14 @@ def bounding_box(seq : BHit) -> Sequence[np.ndarray]:
     return (reduce(np.minimum, posns, MAX3D),
             reduce(np.maximum, posns, MIN3D))
 
+def round_hits_positions_in_place(hits, decimals=5):
+    """
+    Rounds the hits positions to `decimals` decimals to avoid floating point
+    comparison issues. The operation is performed inplace to avoid an
+    unnecessary copy.
+    """
+    for hit in hits:
+        hit.xyz = np.round(hit.xyz, decimals)
 
 def voxelize_hits(hits             : Sequence[BHit],
                   voxel_dimensions : np.ndarray,

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -33,6 +33,7 @@ from .. evm.event_model import Cluster
 from .. evm.event_model import Voxel
 
 from . paolina_functions import bounding_box
+from . paolina_functions import round_hits_positions_in_place
 from . paolina_functions import energy_of_voxels_within_radius
 from . paolina_functions import find_extrema
 from . paolina_functions import find_extrema_and_length
@@ -163,6 +164,24 @@ def test_voxelize_hits_does_not_lose_energy(hits, voxel_dimensions):
         return sum(e.E for e in seq)
 
     assert sum_energy(voxels) == approx(sum_energy(hits))
+
+
+@given(bunch_of_hits)
+def test_round_hits_positions_in_place(hits):
+    """
+    Override xyz such that all values fall below the rounding decimal place. We
+    also multiply some values by -1 to include negative numbers. The maximum
+    absolute value xyz can have is 100. After multiplying by 1e-7, the maximum
+    absolute value is 1e-5. After rounding, the only possible values are 0, 1e-5
+    or -1e-5.
+    """
+    for hit in hits:
+        hit.xyz = np.array(hit.xyz) * 0.999e-7 * [-1, 1, -1]
+
+    round_hits_positions_in_place(hits)
+
+    pos = np.asarray([h.pos for h in hits])
+    assert np.all(np.in1d(pos, [0, 1e-5, -1e-5]))
 
 
 random_graph = builds(partial(fast_gnp_random_graph, p=0.5),

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -131,9 +131,6 @@ def test_voxelize_hits_should_detect_no_hits():
 
 @given(bunch_of_hits)
 def test_bounding_box(hits):
-    if not len(hits): # TODO: deal with empty sequences
-        return
-
     lo, hi = bounding_box(hits)
 
     mins = [float(' inf')] * 3

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -181,6 +181,30 @@ def test_round_hits_positions_in_place(hits):
     assert np.all(np.in1d(pos, [0, 1e-5, -1e-5]))
 
 
+def test_round_hits_positions_in_place_empty_input():
+    """
+    It simply should not crash.
+    """
+    hits = []
+    round_hits_positions_in_place(hits)
+    assert hits == []
+
+
+@settings(max_examples=1) # simple way of producing a single hit
+@given(hit())
+def test_round_hits_positions_in_place_non_finite_values(hit):
+    """
+    Override xyz with np.nan and np.inf, ensure values are not changed.
+    """
+    values = np.nan, np.inf, -np.inf
+    hit.xyz = tuple(values) # ensure copy
+
+    round_hits_positions_in_place([hit])
+
+    assert np.all(np.isclose(hit.pos, values, equal_nan=True))
+
+
+
 random_graph = builds(partial(fast_gnp_random_graph, p=0.5),
                       n=integers(min_value=0, max_value=10),
                       seed=integers())


### PR DESCRIPTION
Some tests that check for an "exact result" have been problematic because they rely on floating point comparisons. This is machine-dependent, which means a test may pass locally, but fail on GHA or viceversa. With direct comparisons, this is usually addressed by adding a tolerance, which we already do. However there are other cases where this isn't enough
- cumulative rounding errors: typical of beersheba, where the iterative process seems to accumulate errors beyond what one might expect using doubles (?)
- discretization of continuous values: typical of paolina, where voxelization is sensible to tiny differences between floating point values, despite our attempts to avoid them.

In this PR, we bypass all these issues by rounding values to a safe number while maintaining enough precision.