### PR TITLE
Remove NNN

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -79,7 +79,6 @@ from .. io     .dst_io            import                 df_writer
 from .. types  .ic_types          import                  NoneType
 from .. types  .ic_types          import                        xy
 from .. types  .ic_types          import                        NN
-from .. types  .ic_types          import                       NNN
 from .. types  .ic_types          import                    minmax
 from .. types  .ic_types          import        types_dict_summary
 from .. types  .ic_types          import         types_dict_tracks

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -1001,7 +1001,7 @@ def build_pointlike_event(dbfile, run_number, drift_v,
             try:
                 clusters = reco(xys, qs)
             except XYRecoFail:
-                c    = NNN()
+                c    = Cluster.empty()
                 Z    = tuple(NN for _ in range(0, evt.nS1))
                 DT   = tuple(NN for _ in range(0, evt.nS1))
                 Zrms = NN

--- a/invisible_cities/types/ic_types.py
+++ b/invisible_cities/types/ic_types.py
@@ -11,11 +11,6 @@ NoneType = type(None)
 
 Tuple2Dor3D = Union[Tuple[float, float], Tuple[float, float, float]]
 
-class NNN:
-
-    def __getattr__(self, _):
-        return NN
-
 
 class xy:
     def __init__(self, x, y):

--- a/invisible_cities/types/ic_types_test.py
+++ b/invisible_cities/types/ic_types_test.py
@@ -5,7 +5,6 @@ import numpy as np
 from . ic_types          import minmax
 from . ic_types          import xy
 from . ic_types          import NN
-from . ic_types          import NNN
 
 from pytest import raises
 
@@ -89,9 +88,3 @@ def test_xy(xy, a, b):
     np.isclose (xy.R  ,   r, rtol=1e-4)
     np.isclose (xy.Phi, phi, rtol=1e-4)
     np.allclose(xy.pos, pos, rtol=1e-3, atol=1e-03)
-
-
-@given(text(min_size=1, max_size=10, alphabet=ascii_letters))
-def test_NNN_generates_NN_for_every_attribute_name(name):
-    nnn = NNN()
-    assert getattr(nnn, name) == NN


### PR DESCRIPTION
This type was used to simplify the NN-ification of clusters. However, it also returns NN (a float) for the `nsipm` attribute, which results in an error when trying to store it as an `uint`.

Since we already have a `Cluster.empty` class method that does the equivalent to `NNN`, and it's more readable, we simply replace one by the other.