### PR TITLE
Refactor `manage.sh`: split activation and installation actions

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Install IC
       run: |
-        source manage.sh activate
+        bash manage.sh install
 
     - name: Run tests
       run: |
@@ -100,7 +100,7 @@ jobs:
     - name: Pyflakes
       run: |
         source scripts/setup_conda_gha.sh
-        source manage.sh work_in_python_version_no_tests ${{ matrix.python-version }}
+        source manage.sh activate
 
         # tee is used to ignore the exit status of pyflakes
         # we don't want the GHA check to fail because of this

--- a/manage.sh
+++ b/manage.sh
@@ -143,16 +143,23 @@ function export_city_command_completion {
 function activate {
     if ! command -v conda 2&>1 > /dev/null
     then
-       install_conda
+        echo "ERROR: Conda not found."
+        echo "Set it up before running this command or run"
+        echo "\nbash manage.sh install_and_check\n"
+        echo "for an automatic conda and IC installation"
+        return
     fi
 
     if ! (conda env list | grep ${CONDA_ENV_NAME}) >> /dev/null
     then
-        make_environment
+        echo "ERROR:IC environment not found"
+        echo "Run"
+        echo "\nbash manage.sh install_and_check\n"
+        echo "to install IC"
+        return
     fi
 
     python_version_env
-    compile_cython_components
     export_city_command_completion
 }
 


### PR DESCRIPTION
Make `activate` responsible only for activating an existing environment.

Remove implicit `conda` and environment installation and cython compilation from activation, since those operations are already handled by dedicated commands. Moreover, the new procedure to compile cython stuff is painfully slow, so it will only be done by default in the installation step.

This avoids unnecessary work during activation and makes command behavior more explicit and predictable at the expense of forcing the user to learn more than one instruction.

A new installation now requires

`bash manage.sh install_and_check`

while, once installed, one just needs to do

`source manage.sh activate`.

The activation step still checks for the availability of conda and the environment to guide the user.
